### PR TITLE
Update copyright notice

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -12,6 +12,13 @@ project adheres to https://semver.org/[Semantic Versioning].
 
 toc::[]
 
+== {compare-url}/v0.1.1\...HEAD[Unreleased]
+
+=== Changed
+
+* Change the comment header to the format recommended by the REUSE
+  Specification ({pull-request-url}/6[#6])
+
 == {compare-url}/v0.1.0\...v0.1.1[0.1.1] - 2023-06-09
 
 === Added

--- a/build.zig
+++ b/build.zig
@@ -1,8 +1,6 @@
+// SPDX-FileCopyrightText: 2023 Shun Sakai
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//
-// Copyright (C) 2023 Shun Sakai
-//
 
 const std = @import("std");
 

--- a/example/isutf8.zig
+++ b/example/isutf8.zig
@@ -1,8 +1,6 @@
+// SPDX-FileCopyrightText: 2023 Shun Sakai
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//
-// Copyright (C) 2023 Shun Sakai
-//
 
 //! An example of checking whether the input is valid UTF-8.
 //! The input is a file or the standard input.

--- a/justfile
+++ b/justfile
@@ -1,8 +1,6 @@
+# SPDX-FileCopyrightText: 2023 Shun Sakai
 #
 # SPDX-License-Identifier: Apache-2.0 OR MIT
-#
-# Copyright (C) 2023 Shun Sakai
-#
 
 alias all := default
 

--- a/src/exit_code.zig
+++ b/src/exit_code.zig
@@ -1,8 +1,6 @@
+// SPDX-FileCopyrightText: 2023 Shun Sakai
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//
-// Copyright (C) 2023 Shun Sakai
-//
 
 //! The system exit code constants as defined by `<sysexits.h>`.
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,8 +1,6 @@
+// SPDX-FileCopyrightText: 2023 Shun Sakai
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-//
-// Copyright (C) 2023 Shun Sakai
-//
 
 //! The `sysexits` package provides the system exit code constants as defined
 //! by `<sysexits.h>`.


### PR DESCRIPTION
Change the comment header to the format recommended by the REUSE Specification.[^1]

[^1]: https://reuse.software/spec/#comment-headers